### PR TITLE
honor root argument when trying to find workspaces

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,7 @@ function getConfiguration(options: SetProjectReferencesOptions): SetProjectRefer
 function setProjectReferences(options: SetProjectReferencesOptions): void {
 	const configuration = getConfiguration(options)
 
-	const workspaces = configuration.hooks.searchWorkspaces(process.cwd())
+	const workspaces = configuration.hooks.searchWorkspaces(options.root)
 		.map(workspacePath => workspaceFactory(workspacePath, null))
 		.filter((workspace): workspace is Workspace => !!workspace)
 


### PR DESCRIPTION
i had to manually cd into common/temp (cause i'm using a rush setup) to get the command to find my workspaces. seems like this option should be reflected here as well?