### PR TITLE
fix(references): don't rewrite references if the arrays are equal despite order differences

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import fs from 'fs'
 import program from 'commander'
 import path from 'path'
 import {
-	difference, isEqual, merge,
+	difference, isEqual, merge, sortBy
 } from 'lodash'
 import JSON from 'comment-json'
 import { version } from './package.json'
@@ -145,7 +145,7 @@ function setProjectReferences(options: SetProjectReferencesOptions): void {
 				!!nullOnNotfound(() => getTsConfigJson(linkedModule.path)))
 			.map(linkedModule => path.relative(module.path, linkedModule.path))
 
-		if (isEqual(currentReferences, desiredReferences) === false) {
+		if (isEqual(sortBy(currentReferences), sortBy(desiredReferences)) === false) {
 			everythingIsFine = false
 			const missingReferences = difference(desiredReferences, currentReferences)
 			const obsoleteReferences = difference(currentReferences, desiredReferences)


### PR DESCRIPTION
Hi again @Bessonov! We are running into a problem where set-project-references is rewriting our file every time and i realized it's because the order of the tsconfig refs can be different from the workspaces deps. It's idempotent so this isn't usually a big deal but the writing of the tsconfig.json also removes the newline we have at the end of our file due to prettier. This causes the build to fail when we check the prettier format later. 

This change causes the tool to do less work and not rewrite when the config is already up to date anyway. I would like to make another pr for adding a newline at the end of the file potentially. Let me know if you're open to that and I'll write it.

Hope you're well!