### PR TITLE
Add flag to return a non-zero exit code if there are mismatched project references

### DIFF
--- a/src/common/SetProjectReferencesOptions.ts
+++ b/src/common/SetProjectReferencesOptions.ts
@@ -2,4 +2,5 @@ export interface SetProjectReferencesOptions {
 	root: string
 	save: boolean
 	indentationTsConfig: string | undefined
+	useExitCode: boolean
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import fs from 'fs'
 import program from 'commander'
 import path from 'path'
 import {
-	difference, isEqual, merge, sortBy
+	difference, isEqual, merge, sortBy,
 } from 'lodash'
 import JSON from 'comment-json'
 import { version } from './package.json'
@@ -176,6 +176,10 @@ function setProjectReferences(options: SetProjectReferencesOptions): void {
 		saveTsConfigJson,
 		options,
 	})
+
+	if (!everythingIsFine && options.useExitCode) {
+		process.exitCode = 1
+	}
 }
 
 program.version(version)
@@ -184,6 +188,7 @@ program
 	.option('-r, --root <path>', 'path to the root of monorepo', process.cwd())
 	.option('-s, --save', 'write changes to the files', false)
 	.option('-t, --indentation-ts-config <chars>', `indentation of tsconfig.json. Use $'\\t' for a tab`)
+	.option('-e, --use-exit-code', 'return a non-zero exit code if there are any discrepancies', false)
 	.action(setProjectReferences)
 
 program.parse(process.argv)


### PR DESCRIPTION
The intent here is to make it easier to create a GH pipeline that uses `set-project-references` to block PRs from being merged if they contain mismatched project references, without trying to fix the mismatched references.

Also fixes the eslint issue on line 7.