### PR TITLE
Fix reference filtering in index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -167,6 +167,7 @@ function setProjectReferences(options: SetProjectReferencesOptions): void {
 				// parse path using native path separators, but always format the output as posix
 				return path.relative(module.path, linkedModule.path).split(path.sep).join(path.posix.sep)
 			})
+			.filter(ref => ref !== '')
 
 		if (isEqual(sortBy(currentReferences), sortBy(desiredReferences)) === false) {
 			everythingIsFine = false


### PR DESCRIPTION
If a reference's path is an empty string, which indicates a circular reference to the module itself (sometimes happening in development when the package lists itself as a devDependency), ignore that reference. Otherwise, tsc will fail with error TS6202.